### PR TITLE
Add AgentBoot — in-browser local LLM for bare-metal hardware detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ Note the condensed table below has two filters applied:
 |  48 | [emeltal](https://github.com/ptsochantaris/emeltal)  | Local ML voice chat using high-end models.  | 175  | 13  | 0  |  1 | 0  | MIT License  | 16 days, 17 hrs, 27 mins |
 |  49 | [lite.koboldai.net](https://github.com/LostRuins/lite.koboldai.net)  | A zero dependency web UI for any LLM backend, including KoboldCpp, OpenAI and AI Horde  | 135  | 68  | 15  |  30 | 0  | GNU Affero General Public License v3.0  | 0 days, 8 hrs, 17 mins  |
 
+## Notable Projects — Local LLM for Edge / Bare-Metal
+
+Projects below are curated additions that don't yet meet the 100-star threshold but are architecturally noteworthy.
+
+| Repo | About | License |
+|------|-------|---------|
+| [AgentBoot](https://github.com/Agnuxo1/AgentBoot-app) | Conversational AI sysadmin: detects bare-metal hardware via chat and guides OS installation. Runs Qwen3 0.8B fully in-browser via wllama (zero server). PWA + Android APK + browser extension + Tauri desktop. BYOK cloud (OpenAI/Claude/Gemini). [Live](https://agentboot.pages.dev) · [HF Space](https://huggingface.co/spaces/Agnuxo/agentboot-demo) | Apache-2.0 |
+
 ## Inspired By
 
 * <https://github.com/janhq/awesome-local-ai>


### PR DESCRIPTION
Add [AgentBoot](https://github.com/Agnuxo1/AgentBoot-app) in a new **Notable Projects — Local LLM for Edge / Bare-Metal** section (the main table is auto-generated by script so this keeps contributions clean).

AgentBoot runs Qwen3 0.8B fully in the browser via wllama — zero server, zero install — and uses it to detect hardware and guide OS installation through conversation. Unique local-LLM edge use case: a sysadmin assistant that works offline on bare metal.

- Live demo: https://agentboot.pages.dev
- HF Space: https://huggingface.co/spaces/Agnuxo/agentboot-demo
- GitHub: https://github.com/Agnuxo1/AgentBoot-app
- License: Apache-2.0