### PR TITLE
Add raullenchai/Rapid-MLX

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -73,5 +73,6 @@
     "run-llama/chat-ui",
     "exo-explore/exo",
     "Jeffser/Alpaca",
-    "sigoden/aichat"
+    "sigoden/aichat",
+    "raullenchai/Rapid-MLX"
 ]


### PR DESCRIPTION
Closes #27

Adds Rapid-MLX (OpenAI-compatible inference server for Apple Silicon) to the repos list.