### PR TITLE
Add sinabarimd/chief-of-staff

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -73,5 +73,6 @@
     "run-llama/chat-ui",
     "exo-explore/exo",
     "Jeffser/Alpaca",
-    "sigoden/aichat"
+    "sigoden/aichat",
+    "sinabarimd/chief-of-staff"
 ]


### PR DESCRIPTION
Adds [chief-of-staff](https://github.com/sinabarimd/chief-of-staff) to `repos.json` so the next refresh picks it up.

## What it is

A reference implementation of a multi-agent personal operating system: eight Claude-based domain agents coordinated by an executive notification layer, plus a fully local voice frontend. The whole voice path lives in 12 GiB of VRAM: WhisperLive (TensorRT Whisper small.en) + Llama 3.1 8B INT4 via vLLM + Kokoro TTS, all on one consumer card. No cloud LLM call on the voice path.

The repo includes the custom Python orchestrator (~2,900 lines), n8n workflow exports, both wake-word models (microWakeWord + openWakeWord), the architectural decision log, and a reproducible token-cost methodology.

Writeup: https://drsinabari.com/articles/chief-of-staff-personal-operating-system.html
License: MIT