### PR TITLE
Consolidate scraping + automate weekly stats updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Required: GitHub token used to read public repo metrics.
+# A read-only classic PAT (no scopes / public_repo) gives 5,000 req/hour.
+GITHUB_API_TOKEN="your_github_token"

--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -1,0 +1,56 @@
+name: Update repo stats
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+# Allow the job to push the refreshed README back to the branch.
+permissions:
+  contents: write
+
+concurrency:
+  group: update-stats
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Fetch metrics and update README
+        env:
+          # Secret must NOT be named GITHUB_*; mapped to the var the script reads.
+          GITHUB_API_TOKEN: ${{ secrets.STATS_GH_PAT }}
+        run: python update_stats.py
+
+      - name: Upload CSV artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-stats-csv
+          path: outputs/*.csv
+          if-no-files-found: warn
+
+      - name: Commit and push README
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Update repo stats ($(date -u +'%Y-%m-%d'))"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Secrets
+.env
+*.pem
+service_account.json
+
+# Python
+.venv/
+__pycache__/
+*.pyc
+
+# Generated outputs (timestamped CSVs)
+outputs/
+
+# macOS
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Vince Lam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
 # 👋 Awesome Local LLMs
 
-There are an overwhelming number of open-source tools for local LLM inference - for both proprietary and open weights LLMs. These tools generally lie within three categories:
+There are an overwhelming number of open-source tools for running LLMs locally and for building on top of them. This repo curates two families of projects and tracks their GitHub metrics as a proxy for popularity and active maintenance:
 
-1. LLM inference backend engine
-2. LLM front end UI
-3. All-in-one desktop application
+- **Local LLM** projects — split into *Inference Backend* engines, *Front-end UI* clients, and *All-in-one App* desktop/mobile apps.
+- **Agent** projects — frameworks, coding agents, research agents, and more.
 
-However these tools can overlap in scope with new features are constantly being added so I have chosen not to manually categorize or label features of each project.
+Each repo is tagged with a **Category** and **Subcategory** so you can tell the types apart at a glance. GitHub metrics (stars, forks, issues, contributors, releases, time since last commit) are refreshed automatically every week by a GitHub Actions workflow.
 
-GitHub repository metrics, like number of stars, contributors, issues, releases, and time since last commit, have been collected as a proxy for popularity and active maintenance.
+**Contributions are welcome!** Suggest a repo I've missed by opening an issue, or add it to [`repos.json`](repos.json) (with its `category` and `subcategory`) and open a pull request. The table below regenerates automatically.
 
-**Contributions are welcome!** Feel free to suggest open-source repos that I have missed either in the Issues of this repo or run the script in the [script](https://github.com/vince-lam/awesome-local-llms/tree/script) branch and update the README and make a pull request.
-
-For full table with all metrics go to this [Google Sheet](https://docs.google.com/spreadsheets/d/1Xv38p90V3GiJXjq0a3qc24056Vicn1I5MG6QiFE6nVE/edit?usp=sharing) or [Airtable](https://airtable.com/apparaKqezkq2LECD/shrE26kWFaVU1cvgb).
+There is also a fuller table of metrics in this [Google Sheet](https://docs.google.com/spreadsheets/d/1Xv38p90V3GiJXjq0a3qc24056Vicn1I5MG6QiFE6nVE/edit?usp=sharing) and [Airtable](https://airtable.com/apparaKqezkq2LECD/shrE26kWFaVU1cvgb) _(no longer updated — kept for reference)_.
 
 For my thoughts on local LLM tooling: <https://vinlam.com/posts/local-llm-options/>
 
@@ -21,61 +18,36 @@ Note the condensed table below has two filters applied:
 1. Repositories need more than 100 stars
 2. Repositories require a commit within the last 60 days
 
-## Open-Source Local LLM Projects
+## Open-Source LLM & Agent Projects
 
-*Last Updated: 08/09/2025*
+*Last Updated: (pending first automated run)*
 
-|  # | Repo  | About  | Stars  | Forks  | Issues  |  Contributors | Releases  | License  | Time Since Last Commit  |
-|----------|----------|----------|----------|----------|----------|----------|----------|----------|----------|
-|  1 | [ollama](https://github.com/ollama/ollama)  | Get up and running with OpenAI gpt-oss, DeepSeek-R1, Gemma 3 and other models.  | 151,867 | 13,052  | 2,126  |  461 | 147  | MIT License  | 2 days, 15 hrs, 0 mins  |
-|  2 | [transformers](https://github.com/huggingface/transformers)  | 🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training.  | 149,300 | 30,300  | 1,995  |  436 | 227  | Apache License 2.0  | 0 days, 8 hrs, 20 mins  |
-|  3 | [open-webui](https://github.com/open-webui/open-webui)  | User-friendly AI Interface (Supports Ollama, OpenAI API, ...)  | 109,207 | 14,926  | 276  |  393 | 123  | Other  | 0 days, 18 hrs, 8 mins  |
-|  4 | [llama.cpp](https://github.com/ggerganov/llama.cpp)  | LLM inference in C/C++  | 86,200  | 12,958  | 880  |  451 | 4,182  | MIT License  | 0 days, 8 hrs, 23 mins  |
-|  5 | [ChatGPT-Next-Web](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web)  | ✨ Light and Fast AI Assistant. Support: Web, iOS, MacOS, Android, Linux, Windows  | 85,783  | 61,027  | 764  |  261 | 77  | MIT License  | 9 days, 1 hrs, 46 mins  |
-|  6 | [gpt_academic](https://github.com/binary-husky/gpt_academic)  | 为GPT/GLM等LLM大语言模型提供实用化交互接口，特别优化论文阅读/润色/写作体验，模块化设计，支持自定义快捷按钮&函数插件，支持Python和C++等项目剖析&自译解功能，PDF/LaTex论文翻译&总结功能，支持并行问询多种LLM模型，支持chatglm3等本地模型。接入通义千问, deepseekcoder, 讯飞星火, 文心一言, llama2, rwkv, claude2, moss等。  | 69,207  | 8,374  | 286  |  102 | 32  | GNU General Public License v3.0  | 15 days, 4 hrs, 2 mins  |
-|  7 | [lobe-chat](https://github.com/lobehub/lobe-chat)  | 🤯 Lobe Chat - an open-source, modern design AI chat framework. Supports multiple AI providers (OpenAI / Claude 4 / Gemini / DeepSeek / Ollama / Qwen), Knowledge Base (file upload / RAG ), one click install MCP Marketplace and Artifacts / Thinking. One-click FREE deployment of your private AI Agent application.  | 65,309  | 13,530  | 997  |  262 | 2,019  | Other  | 0 days, 10 hrs, 8 mins  |
-|  8 | [gpt4free](https://github.com/xtekky/gpt4free)  | The official gpt4free repository, various collection of powerful language models: o4, o3 and deepseek r1, gpt-4.1, gemini 2.5  | 65,060  | 13,683  | 11  |  247 | 347  | GNU General Public License v3.0  | 0 days, 8 hrs, 54 mins  |
-|  9 | [vllm](https://github.com/vllm-project/vllm)  | A high-throughput and memory-efficient inference and serving engine for LLMs  | 57,434  | 9,971  | 2,949  |  458 | 73  | Apache License 2.0  | 0 days, 9 hrs, 27 mins  |
-|  10 | [anything-llm](https://github.com/Mintplex-Labs/anything-llm)  | The all-in-one Desktop & Docker AI application with built-in RAG, AI agents, No-code agent builder, MCP compatibility,  and more.  | 48,752  | 5,031  | 313  |  149 | 20  | MIT License  | 2 days, 15 hrs, 51 mins  |
-|  11 | [text-generation-webui](https://github.com/oobabooga/text-generation-webui)  | The definitive Web UI for local AI, with powerful features and easy setup.  | 44,902  | 5,772  | 2,588  |  359 | 81  | GNU Affero General Public License v3.0  | 4 days, 16 hrs, 54 mins  |
-|  12 | [jan](https://github.com/janhq/jan)  | Jan is an open source alternative to ChatGPT that runs 100% offline on your computer  | 37,712  | 2,229  | 171  |  92 | 88  | Other  | 0 days, 8 hrs, 50 mins  |
-|  13 | [chatbox](https://github.com/Bin-Huang/chatbox)  | User-friendly Desktop Client App for AI Models/LLMs (GPT, Claude, Gemini, Ollama...)  | 36,501  | 3,514  | 892  |  55 | 47  | GNU General Public License v3.0  | 19 days, 8 hrs, 22 mins  |
-|  14 | [LocalAI](https://github.com/mudler/LocalAI)  | :robot: The free, Open Source alternative to OpenAI, Claude and others. Self-hosted and local-first. Drop-in replacement for OpenAI,  running on consumer-grade hardware. No GPU required. Runs gguf, transformers, diffusers and many more models architectures. Features: Generate Text, Audio, Video, Images, Voice Cloning, Distributed, P2P inference | 35,118  | 2,751  | 371  |  142 | 84  | MIT License  | 0 days, 8 hrs, 51 mins  |
-|  15 | [LibreChat](https://github.com/danny-avila/LibreChat)  | Enhanced ChatGPT Clone: Features Agents, DeepSeek, Anthropic, AWS, OpenAI, Responses API, Azure, Groq, o1, GPT-5, Mistral, OpenRouter, Vertex AI, Gemini, Artifacts, AI model switching, message search, Code Interpreter, langchain, DALL-E-3, OpenAPI Actions, Functions, Secure Multi-User Auth, Presets, open-source for self-hosting. Active project. | 29,816  | 5,617  | 270  |  246 | 59  | MIT License  | 0 days, 14 hrs, 36 mins  |
-|  16 | [localGPT](https://github.com/PromtEngineer/localGPT)  | Chat with your documents on your local device using GPT models. No data leaves your device and 100% private.  | 21,841  | 2,428  | 14  |  45 | 0  | MIT License  | 44 days, 13 hrs, 8 mins  |
-|  17 | [mlc-llm](https://github.com/mlc-ai/mlc-llm)  | Universal LLM Deployment Engine with ML Compilation  | 21,285  | 1,808  | 321  |  141 | 1  | Apache License 2.0  | 0 days, 12 hrs, 52 mins  |
-|  18 | [SillyTavern](https://github.com/SillyTavern/SillyTavern)  | LLM Frontend for Power Users.  | 18,245  | 3,930  | 344  |  267 | 95  | GNU Affero General Public License v3.0  | 0 days, 10 hrs, 44 mins  |
-|  19 | [ChuanhuChatGPT](https://github.com/GaiZhenbiao/ChuanhuChatGPT)  | GUI for ChatGPT API and many LLMs. Supports agents, file-based QA, GPT finetuning and query with web search. All with a neat UI.  | 15,436  | 2,273  | 124  |  51 | 27  | GNU General Public License v3.0  | 24 days, 14 hrs, 26 mins |
-|  20 | [OpenLLM](https://github.com/bentoml/OpenLLM)  | Run any open-source LLMs, such as DeepSeek and Llama, as OpenAI compatible API endpoint in the cloud.  | 11,754  | 764  | 7  |  31 | 147  | Apache License 2.0  | 6 days, 23 hrs, 59 mins  |
-|  21 | [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)  | TensorRT-LLM provides users with an easy-to-use Python API to define Large Language Models (LLMs) and support state-of-the-art optimizations to perform inference efficiently on NVIDIA GPUs. TensorRT-LLM also contains components to create Python and C++ runtimes that orchestrate the inference execution in performant way.  | 11,535  | 1,722  | 1,139  |  248 | 39  | Apache License 2.0  | 0 days, 8 hrs, 8 mins  |
-|  22 | [text-generation-inference](https://github.com/huggingface/text-generation-inference) | Large Language Model Text Generation Inference  | 10,486  | 1,227  | 312  |  142 | 65  | Apache License 2.0  | 0 days, 22 hrs, 51 mins  |
-|  23 | [server](https://github.com/triton-inference-server/server)  | The Triton Inference Server provides an optimized cloud and edge inferencing solution.  | 9,743  | 1,639  | 827  |  132 | 82  | BSD 3-Clause "New" or "Revised" License | 1 days, 3 hrs, 49 mins  |
-|  24 | [llm](https://github.com/simonw/llm)  | Access large language models from the command-line  | 9,617  | 600  | 494  |  52 | 55  | Apache License 2.0  | 27 days, 11 hrs, 33 mins |
-|  25 | [llama-cpp-python](https://github.com/abetlen/llama-cpp-python)  | Python bindings for llama.cpp  | 9,548  | 1,220  | 653  |  166 | 307  | MIT License  | 24 days, 10 hrs, 28 mins |
-|  26 | [chat-ui](https://github.com/huggingface/chat-ui)  | Open source codebase powering the HuggingChat app  | 9,138  | 1,418  | 339  |  140 | 16  | Apache License 2.0  | 37 days, 21 hrs, 39 mins |
-|  27 | [inference](https://github.com/xorbitsai/inference)  | Replace OpenAI GPT with another LLM in your app by changing a single line of code. Xinference gives you the freedom to use any LLM you need. With Xinference, you're empowered to run inference with any open-source language models, speech recognition models, and multimodal models, whether in the cloud, on-premises, or even on your laptop.  | 8,496  | 738  | 166  |  116 | 118  | Apache License 2.0  | 0 days, 13 hrs, 54 mins  |
-|  28 | [koboldcpp](https://github.com/LostRuins/koboldcpp)  | Run GGUF models easily with a KoboldAI UI. One File. Zero Install.  | 8,168  | 528  | 347  |  447 | 110  | GNU Affero General Public License v3.0  | 0 days, 8 hrs, 47 mins  |
-|  29 | [page-assist](https://github.com/n4ze3m/page-assist)  | Use your locally running AI models to assist you in your web browsing  | 7,085  | 632  | 294  |  30 | 64  | MIT License  | 1 days, 1 hrs, 11 mins  |
-|  30 | [lmdeploy](https://github.com/InternLM/lmdeploy)  | LMDeploy is a toolkit for compressing, deploying, and serving LLMs.  | 6,981  | 599  | 515  |  124 | 54  | Apache License 2.0  | 0 days, 11 hrs, 4 mins  |
-|  31 | [big-agi](https://github.com/enricoros/big-agi)  | AI suite powered by state-of-the-art models and providing advanced AI/AGI functions. It features AI personas, AGI functions, multi-model chats, text-to-image, voice, response streaming, code highlighting and execution, PDF import, presets for developers, much more. Deploy on-prem or in the cloud.  | 6,609  | 1,543  | 266  |  46 | 16  | MIT License  | 3 days, 18 hrs, 39 mins  |
-|  32 | [openplayground](https://github.com/nat/openplayground)  | An LLM playground you can run on your laptop  | 6,359  | 491  | 96  |  15 | 0  | MIT License  | 31 days, 9 hrs, 42 mins  |
-|  33 | [lollms-webui](https://github.com/ParisNeo/lollms-webui)  | Lord of Large Language and Multi modal Systems Web User Interface  | 4,748  | 581  | 172  |  40 | 24  | Apache License 2.0  | 19 days, 2 hrs, 5 mins  |
-|  34 | [pocketpal-ai](https://github.com/a-ghorbani/pocketpal-ai)  | An app that brings language models directly to your phone.  | 4,735  | 441  | 91  |  14 | 48  | MIT License  | 19 days, 1 hrs, 58 mins  |
-|  35 | [exllamav2](https://github.com/turboderp/exllamav2)  | A fast inference library for running LLMs locally on modern consumer-class GPUs  | 4,306  | 320  | 153  |  52 | 43  | MIT License  | 22 days, 18 hrs, 48 mins |
-|  36 | [LLamaSharp](https://github.com/SciSharp/LLamaSharp)  | A C#/.NET library to run LLM (🦙LLaMA/LLaVA) on your local device efficiently.  | 3,349  | 465  | 30  |  76 | 28  | MIT License  | 7 days, 4 hrs, 30 mins  |
-|  37 | [oterm](https://github.com/ggozad/oterm)  | the terminal client for Ollama  | 2,162  | 126  | 9  |  21 | 69  | MIT License  | 1 days, 1 hrs, 10 mins  |
-|  38 | [maid](https://github.com/Mobile-Artificial-Intelligence/maid)  | Maid is a cross-platform Flutter app for interfacing with GGUF / llama.cpp models locally, and with Ollama and OpenAI models remotely.  | 2,148  | 218  | 15  |  28 | 38  | MIT License  | 42 days, 3 hrs, 20 mins  |
-|  39 | [LLMFarm](https://github.com/guinmoon/LLMFarm)  | llama and other  large language models on iOS and MacOS offline using GGML library.  | 1,861  | 153  | 42  |  1 | 34  | MIT License  | 30 days, 21 hrs, 36 mins |
-|  40 | [ChatterUI](https://github.com/Vali-98/ChatterUI)  | Simple frontend for LLMs built in react-native.  | 1,790  | 131  | 23  |  8 | 78  | GNU Affero General Public License v3.0  | 17 days, 3 hrs, 47 mins  |
-|  41 | [chatbot-ollama](https://github.com/ivanfioravanti/chatbot-ollama)  | Chatbot Ollama is an open source chat UI for Ollama.  | 1,778  | 313  | 20  |  8 | 3  | Other  | 2 days, 21 hrs, 52 mins  |
-|  42 | [Alpaca](https://github.com/Jeffser/Alpaca)  | 🦙 Local and online AI hub  | 1,184  | 104  | 83  |  49 | 87  | GNU General Public License v3.0  | 0 days, 16 hrs, 5 mins  |
-|  43 | [amica](https://github.com/semperai/amica)  | Amica is an open source interface for interactive communication with 3D characters with voice synthesis and speech recognition.  | 1,067  | 188  | 15  |  21 | 4  | MIT License  | 46 days, 19 hrs, 48 mins |
-|  44 | [web-llm-chat](https://github.com/mlc-ai/web-llm-chat)  | Chat with AI large language models running natively in your browser. Enjoy private, server-free, seamless AI conversations.  | 836  | 149  | 18  |  180 | 0  | Apache License 2.0  | 5 days, 0 hrs, 0 mins  |
-|  45 | [tenere](https://github.com/pythops/tenere)  | 🤖 TUI interface for LLMs written in Rust  | 579  | 25  | 12  |  10 | 14  | GNU General Public License v3.0  | 6 days, 21 hrs, 59 mins  |
-|  46 | [chat-ui](https://github.com/run-llama/chat-ui)  | Chat UI components for LLM apps  | 497  | 54  | 9  |  15 | 51  | MIT License  | 11 days, 14 hrs, 32 mins |
-|  47 | [ava](https://github.com/cztomsik/ava)  | All-in-one desktop app for running LLMs locally.  | 457  | 17  | 4  |  3 | 0  | Other  | 6 days, 2 hrs, 3 mins  |
-|  48 | [emeltal](https://github.com/ptsochantaris/emeltal)  | Local ML voice chat using high-end models.  | 175  | 13  | 0  |  1 | 0  | MIT License  | 16 days, 17 hrs, 27 mins |
-|  49 | [lite.koboldai.net](https://github.com/LostRuins/lite.koboldai.net)  | A zero dependency web UI for any LLM backend, including KoboldCpp, OpenAI and AI Horde  | 135  | 68  | 15  |  30 | 0  | GNU Affero General Public License v3.0  | 0 days, 8 hrs, 17 mins  |
+<!-- BEGIN_TABLE -->
+_The table is generated automatically by `update_stats.py`. Run it locally or trigger the "Update repo stats" workflow to populate this section._
+<!-- END_TABLE -->
+
+## How it works
+
+[`update_stats.py`](update_stats.py) reads [`repos.json`](repos.json), pulls metrics from the GitHub API, writes a full timestamped CSV to `outputs/`, and injects the filtered table above between the `BEGIN_TABLE` / `END_TABLE` markers.
+
+The condensed table above is filtered to repos with **more than 100 stars** and a **commit within the last 60 days**. The full, unfiltered dataset (every tracked repo, all columns) is produced as the `outputs/` CSV, which the weekly workflow also uploads as a build artifact.
+
+### Run it yourself
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env   # then add your GitHub token
+python update_stats.py
+```
+
+### Automated weekly updates
+
+The [`Update repo stats`](.github/workflows/update-stats.yml) GitHub Actions workflow runs every Monday (and on demand via *Run workflow*), regenerates the table, and commits the refreshed README back to `main`. It needs one repository secret (Settings → Secrets and variables → Actions):
+
+| Secret | Purpose |
+|--------|---------|
+| `STATS_GH_PAT` | GitHub read-only PAT (5,000 req/hour; the built-in token's 1,000/hour isn't enough for ~190 repos) |
 
 ## Inspired By
 

--- a/repos.json
+++ b/repos.json
@@ -1,0 +1,952 @@
+[
+  {
+    "repo": "ggerganov/llama.cpp",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "ollama/ollama",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "open-webui/open-webui",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "LostRuins/koboldcpp",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "janhq/jan",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "nat/openplayground",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "Mozilla-Ocho/llamafile",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "nomic-ai/gpt4all",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "oobabooga/text-generation-webui",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "psugihara/FreeChat",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "cztomsik/ava",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "withcatai/catai",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "Mobile-Artificial-Intelligence/maid",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "mudler/LocalAI",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "ptsochantaris/emeltal",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "pythops/tenere",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "semperai/amica",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "guinmoon/LLMFarm",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "h2oai/h2ogpt",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "imartinez/privateGPT",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "huggingface/chat-ui",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "ParisNeo/lollms-webui",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "simonw/llm",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "lobehub/lobe-chat",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "PromtEngineer/localGPT",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "Mintplex-Labs/anything-llm",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "SillyTavern/SillyTavern",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "vllm-project/vllm",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "turboderp/exui",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "turboderp/exllama",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "turboderp/exllamav2",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "huggingface/transformers",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "mckaywrigley/chatbot-ui",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "ivanfioravanti/chatbot-ollama",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "lmg-anon/mikupad",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "LostRuins/lite.koboldai.net",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "mlc-ai/mlc-llm",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "ortegaalfredo/neurochat",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "KoljaB/LocalAIVoiceChat",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "nathanlesage/local-chat",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "janhq/nitro",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "InternLM/lmdeploy",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "NVIDIA/TensorRT-LLM",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "marella/ctransformers",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "abetlen/llama-cpp-python",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "srush/llama2.rs",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "enricoros/big-agi",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "ggozad/oterm",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "ChatGPTNextWeb/ChatGPT-Next-Web",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "Bin-Huang/chatbox",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "danny-avila/LibreChat",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "minimaxir/simpleaichat",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "SciSharp/LLamaSharp",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "xtekky/gpt4free",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "FMInference/FlexGen",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "deep-diver/LLM-As-Chatbot",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "GaiZhenbiao/ChuanhuChatGPT",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "chathub-dev/chathub",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "mlc-ai/web-llm",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "bentoml/OpenLLM",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "binary-husky/gpt_academic",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "triton-inference-server/server",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "huggingface/text-generation-inference",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "xorbitsai/inference",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "elgatopanzon/gatogpt",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "Vali-98/ChatterUI",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "dbddv01/GPT-Sequencer",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "n4ze3m/page-assist",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "mlc-ai/web-llm-chat",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "janhq/cortex.cpp",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "a-ghorbani/pocketpal-ai",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "run-llama/chat-ui",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "exo-explore/exo",
+    "category": "Local LLM",
+    "subcategory": "Inference Backend"
+  },
+  {
+    "repo": "Jeffser/Alpaca",
+    "category": "Local LLM",
+    "subcategory": "All-in-one App"
+  },
+  {
+    "repo": "sigoden/aichat",
+    "category": "Local LLM",
+    "subcategory": "Front-end UI"
+  },
+  {
+    "repo": "meta-llama/llama-stack-apps",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "run-llama/llama_index",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "langchain-ai/langchain",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "botpress/botpress",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "deepset-ai/haystack",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "microsoft/semantic-kernel",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "Josh-XT/AGiXT",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "mpaepper/llm_agents",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "e2b-dev/e2b",
+    "category": "Agent",
+    "subcategory": "Runtime"
+  },
+  {
+    "repo": "dust-tt/dust",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "geekan/MetaGPT",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "simonmesmith/agentflow",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "InternLM/lagent",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "microsoft/autogen",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "openbmb/agentverse",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "Doriandarko/maestro",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "modelscope/agentscope",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "crewAIInc/crewAI",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "openai/swarm",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "VRSEN/agency-swarm",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "simbianai/taskgen",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "tanchongmin/agentjo",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "Pythagora-io/gpt-pilot",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "stanfordnlp/dspy",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "alaeddine-13/thinkgpt",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "chakkaradeep/pyCodeAGI",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "TransformerOptimus/SuperAGI",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "plandex-ai/plandex",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "semanser/codel",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "csunny/DB-GPT",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "neurocult/agency",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "microsoft/TaskWeaver",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "aymenfurter/microagents",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "princeton-nlp/swe-agent",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "Jonathan-Adly/AgentRun",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "Doriandarko/claude-engineer",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "landing-ai/vision-agent",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "TrafficGuard/nous",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "assafelovic/gpt-researcher",
+    "category": "Agent",
+    "subcategory": "Research"
+  },
+  {
+    "repo": "blockpipe/blockagi",
+    "category": "Agent",
+    "subcategory": "Research"
+  },
+  {
+    "repo": "Technion-Kishony-lab/data-to-paper",
+    "category": "Agent",
+    "subcategory": "Research"
+  },
+  {
+    "repo": "SakanaAI/AI-Scientist",
+    "category": "Agent",
+    "subcategory": "Research"
+  },
+  {
+    "repo": "stanford-oval/storm",
+    "category": "Agent",
+    "subcategory": "Research"
+  },
+  {
+    "repo": "hpcaitech/ColossalAI",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "paulpierre/RasaGPT",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "homanp/superagent",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "miurla/babyagi-ui",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "kreneskyp/ix",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "kristoferlund/duet-gpt",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "steamship-packages/langchain-agent-production-starter",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "stepanogil/autonomous-hr-chatbot",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "Maximilian-Winter/llama-cpp-agent",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "cpacker/memgpt",
+    "category": "Agent",
+    "subcategory": "Chat"
+  },
+  {
+    "repo": "reworkd/AgentGPT",
+    "category": "Agent",
+    "subcategory": "Browser"
+  },
+  {
+    "repo": "langchain-ai/langgraph",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "ComposioHQ/composio",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "phidatahq/phidata",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "ErikBjare/gptme",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "awslabs/multi-agent-orchestrator",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "sourcegraph/cody",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "xlang-ai/OpenAgents",
+    "category": "Agent",
+    "subcategory": "Browser"
+  },
+  {
+    "repo": "Aider-AI/aider",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "All-Hands-AI/OpenHands",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "stitionai/devika",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "OpenBMB/RepoAgent",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "SamurAIGPT/GPT-Agent",
+    "category": "Agent",
+    "subcategory": "Gaming"
+  },
+  {
+    "repo": "litanlitudan/skyagi",
+    "category": "Agent",
+    "subcategory": "Gaming"
+  },
+  {
+    "repo": "MineDojo/Voyager",
+    "category": "Agent",
+    "subcategory": "Gaming"
+  },
+  {
+    "repo": "melih-unsal/DemoGPT",
+    "category": "Agent",
+    "subcategory": "Automation"
+  },
+  {
+    "repo": "Yifan-Song793/RestGPT",
+    "category": "Agent",
+    "subcategory": "Automation"
+  },
+  {
+    "repo": "OpenBMB/XAgent",
+    "category": "Agent",
+    "subcategory": "Automation"
+  },
+  {
+    "repo": "fetchai/uAgents",
+    "category": "Agent",
+    "subcategory": "Automation"
+  },
+  {
+    "repo": "mikekelly/AgentK",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "OpenInterpreter/open-interpreter",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "team-openpm/workgpt",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "Canner/WrenAI",
+    "category": "Agent",
+    "subcategory": "Data Analysis"
+  },
+  {
+    "repo": "vanna-ai/vanna",
+    "category": "Agent",
+    "subcategory": "Data Analysis"
+  },
+  {
+    "repo": "WecoAI/aideml",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "smol-ai/developer",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "continuedev/continue",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "joshpxyne/gpt-migrate",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "gpt-engineer-org/gpt-engineer",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "eylonmiz/react-agent",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "uilicious/english-compiler",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "irgolic/AutoPR",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "LehengTHU/Agent4Rec",
+    "category": "Agent",
+    "subcategory": "Research"
+  },
+  {
+    "repo": "myshell-ai/AIlice",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "topoteretes/PromethAI-Backend",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "trypromptly/LLMStack",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "Significant-Gravitas/AutoGPT",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "AutoPackAI/beebot",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "yoheinakajima/babyagi",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "Farama-Foundation/chatarena",
+    "category": "Agent",
+    "subcategory": "Gaming"
+  },
+  {
+    "repo": "Kav-K/GPTDiscord",
+    "category": "Agent",
+    "subcategory": "Conversational"
+  },
+  {
+    "repo": "agentcoinorg/evo.ninja",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "muellerberndt/mini-agi",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "sidhq/Multi-GPT",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "letta-ai/letta",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "superagent-ai/superagent",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "abi/screenshot-to-code",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "OpenBMB/ChatDev",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "krohling/bondai",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "FlowiseAI/Flowise",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "HumanSignal/Adala",
+    "category": "Agent",
+    "subcategory": "Data Analysis"
+  },
+  {
+    "repo": "bexta/AgentPilot",
+    "category": "Agent",
+    "subcategory": "General"
+  },
+  {
+    "repo": "airtai/fastagency",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "DataBassGit/AgentForge",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "corbt/agent.exe",
+    "category": "Agent",
+    "subcategory": "GUI"
+  },
+  {
+    "repo": "ennucore/clippinator",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "langroid/langroid",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "frdel/agent-zero",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "langgenius/dify",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "trypear/pearai-app",
+    "category": "Agent",
+    "subcategory": "Coding"
+  },
+  {
+    "repo": "yoheinakajima/babyagi-2o",
+    "category": "Agent",
+    "subcategory": "Framework"
+  },
+  {
+    "repo": "elizaOS/eliza",
+    "category": "Agent",
+    "subcategory": "Framework"
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas>=2.2
+requests>=2.31
+tabulate>=0.9
+python-dotenv>=1.0

--- a/update_stats.py
+++ b/update_stats.py
@@ -1,0 +1,289 @@
+"""Fetch GitHub metrics for the curated repos and refresh the README table.
+
+Reads ``repos.json`` (a list of ``{repo, category, subcategory}`` entries),
+pulls metrics from the GitHub API, writes a timestamped CSV to ``outputs/`` and
+injects a filtered, sorted Markdown table into ``README.md`` between the
+``<!-- BEGIN_TABLE -->`` / ``<!-- END_TABLE -->`` markers.
+"""
+
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+import pandas as pd
+import requests
+from requests.adapters import HTTPAdapter
+from tabulate import tabulate
+from urllib3.util.retry import Retry
+
+API_ROOT = "https://api.github.com"
+CONFIG_FILE = "repos.json"
+README_FILE = "README.md"
+OUTPUT_DIR = "outputs"
+
+# README table filters
+MIN_STARS = 100
+MAX_DAYS_SINCE_COMMIT = 60
+
+# Full column order for the CSV.
+FULL_COLUMNS = [
+    "Owner",
+    "Repository Name",
+    "Category",
+    "Subcategory",
+    "About",
+    "Stars",
+    "Forks",
+    "Issues",
+    "Contributors",
+    "Releases",
+    "Watchers",
+    "Time Since Last Commit",
+    "License",
+    "Languages",
+    "URL",
+]
+
+# Column order for the condensed README table.
+README_COLUMNS = [
+    "#",
+    "Repo",
+    "Category",
+    "Subcategory",
+    "About",
+    "Stars",
+    "Forks",
+    "Issues",
+    "Contributors",
+    "Releases",
+    "License",
+    "Time Since Last Commit",
+]
+
+
+def get_token() -> str:
+    """Return the GitHub token from the environment (CI or local .env)."""
+    # Load a local .env if python-dotenv is available; harmless in CI.
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GITHUB_API_TOKEN")
+    if not token:
+        sys.exit(
+            "Error: no GitHub token found. Set GITHUB_TOKEN (CI) or "
+            "GITHUB_API_TOKEN in your .env file."
+        )
+    return token
+
+
+def make_session(token: str) -> requests.Session:
+    """Build a requests session with auth headers and retry/backoff."""
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+    )
+    retry = Retry(
+        total=5,
+        backoff_factor=2,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retry))
+    return session
+
+
+def check_token(session: requests.Session) -> bool:
+    """Verify the token works before scraping everything."""
+    resp = session.get(f"{API_ROOT}/user")
+    if resp.status_code == 401:
+        print("Error: invalid or expired GitHub token.")
+        return False
+    return resp.ok
+
+
+def count_paginated(session: requests.Session, url: str) -> int:
+    """Count items across a paginated endpoint (contributors, releases)."""
+    count = 0
+    page = 1
+    while True:
+        resp = session.get(url, params={"page": page, "per_page": 100})
+        resp.raise_for_status()
+        items = resp.json()
+        if not items:
+            break
+        count += len(items)
+        if len(items) < 100:
+            break
+        page += 1
+    return count
+
+
+def fetch_repo_info(
+    session: requests.Session, entry: Dict[str, str]
+) -> Optional[Dict[str, object]]:
+    """Fetch metrics for a single repo entry."""
+    repo = entry["repo"]
+    base_url = f"{API_ROOT}/repos/{repo}"
+    try:
+        resp = session.get(base_url)
+        resp.raise_for_status()
+        data = resp.json()
+
+        contributors = count_paginated(session, f"{base_url}/contributors")
+        releases = count_paginated(session, f"{base_url}/releases")
+
+        langs_resp = session.get(f"{base_url}/languages")
+        langs_resp.raise_for_status()
+        languages = ", ".join(langs_resp.json().keys())
+
+        last_commit = datetime.strptime(data["pushed_at"], "%Y-%m-%dT%H:%M:%SZ")
+        delta = datetime.now(timezone.utc).replace(tzinfo=None) - last_commit
+        days, rem = divmod(delta.total_seconds(), 86400)
+        hours, rem = divmod(rem, 3600)
+        minutes, _ = divmod(rem, 60)
+
+        license_info = (
+            data["license"]["name"]
+            if data.get("license")
+            else "No license"
+        )
+
+        stats = {
+            "Owner": repo.split("/")[0],
+            "Repository Name": repo.split("/")[1],
+            "Category": entry.get("category", ""),
+            "Subcategory": entry.get("subcategory", ""),
+            "About": data.get("description") or "No description available",
+            "Stars": data.get("stargazers_count", 0),
+            "Forks": data.get("forks_count", 0),
+            "Issues": data.get("open_issues_count", 0),
+            "Contributors": contributors,
+            "Releases": releases,
+            "Watchers": data.get("subscribers_count", 0),
+            "Time Since Last Commit": (
+                f"{int(days)} days, {int(hours)} hrs, {int(minutes)} mins"
+            ),
+            "License": license_info,
+            "Languages": languages,
+            "URL": f"https://github.com/{repo}",
+            # numeric helper for sorting/filtering, dropped before output
+            "_stars": data.get("stargazers_count", 0),
+            "_days": int(days),
+        }
+        print(f"  ok: {repo} ({stats['Stars']} stars)")
+        return stats
+    except requests.exceptions.HTTPError as err:
+        print(f"  skip: {repo} - HTTP error: {err}")
+    except Exception as err:  # noqa: BLE001 - keep going on any single repo
+        print(f"  skip: {repo} - error: {err}")
+    return None
+
+
+def fetch_all(session: requests.Session, entries: List[Dict[str, str]]) -> pd.DataFrame:
+    rows = []
+    for i, entry in enumerate(entries, 1):
+        print(f"[{i}/{len(entries)}] {entry['repo']}")
+        info = fetch_repo_info(session, entry)
+        if info:
+            rows.append(info)
+    if not rows:
+        sys.exit("Error: no repository data fetched.")
+    df = pd.DataFrame(rows).drop_duplicates(subset=["URL"])
+    df = df.sort_values(by="_stars", ascending=False).reset_index(drop=True)
+    return df
+
+
+def format_numbers(df: pd.DataFrame) -> pd.DataFrame:
+    """Format numeric metric columns with thousands separators (as strings)."""
+    df = df.copy()
+    for col in ["Stars", "Forks", "Issues", "Contributors", "Releases", "Watchers"]:
+        df[col] = df[col].apply(lambda x: f"{int(x):,}")
+    return df
+
+
+def write_csv(df: pd.DataFrame) -> str:
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    stamp = datetime.now().strftime("%Y-%m-%d_%H%M")
+    path = os.path.join(OUTPUT_DIR, f"{stamp}_repo_stats.csv")
+    df[FULL_COLUMNS].to_csv(path, index=False)
+    print(f"Wrote {path}")
+    return path
+
+
+def build_markdown_table(df: pd.DataFrame) -> str:
+    """Build the condensed, filtered Markdown table for the README."""
+    table = df[(df["_stars"] > MIN_STARS) & (df["_days"] <= MAX_DAYS_SINCE_COMMIT)].copy()
+    table = table.reset_index(drop=True)
+    table["#"] = table.index + 1
+    table["Repo"] = table.apply(
+        lambda r: f'[{r["Repository Name"]}]({r["URL"]})', axis=1
+    )
+    table = format_numbers(table)[README_COLUMNS]
+    md = tabulate(table, headers="keys", tablefmt="github", showindex=False)
+    md = re.sub(r" {3,}", "  ", md)
+    md = re.sub(r"-{4,}", "----------", md)
+    return md
+
+
+def update_readme(markdown_table: str) -> None:
+    """Inject the table and refresh the Last Updated line in README.md."""
+    with open(README_FILE, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    today = datetime.now().strftime("%d/%m/%Y")
+    content = re.sub(
+        r"\*Last Updated:.*?\*",
+        f"*Last Updated: {today}*",
+        content,
+        count=1,
+    )
+
+    block = f"<!-- BEGIN_TABLE -->\n{markdown_table}\n<!-- END_TABLE -->"
+    if "<!-- BEGIN_TABLE -->" not in content:
+        sys.exit(
+            "Error: README.md is missing the <!-- BEGIN_TABLE --> / "
+            "<!-- END_TABLE --> markers."
+        )
+    content = re.sub(
+        r"<!-- BEGIN_TABLE -->.*?<!-- END_TABLE -->",
+        block,
+        content,
+        flags=re.DOTALL,
+    )
+
+    with open(README_FILE, "w", encoding="utf-8") as f:
+        f.write(content)
+    print(f"Updated {README_FILE}")
+
+
+def main() -> None:
+    start = time.time()
+    token = get_token()
+    session = make_session(token)
+    if not check_token(session):
+        sys.exit(1)
+
+    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        entries = json.load(f)
+
+    df = fetch_all(session, entries)
+    csv_path = write_csv(df)
+    update_readme(build_markdown_table(df))
+
+    mins, secs = divmod(time.time() - start, 60)
+    print(f"Done in {int(mins)}m {int(secs)}s. CSV: {csv_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Merge repos.json + agents.json into one unified repos.json with category/subcategory per repo (Local LLM vs Agent + subtypes)
- Replace the two near-identical scripts with a single update_stats.py (fetch -> CSV -> inject README table between markers)
- Add weekly GitHub Actions workflow that commits the refreshed README
- Add requirements.txt, fix .env.example token name, harden .gitignore
- Rework README: merged scope, Category/Subcategory columns, table markers, setup + secrets docs