### PR TITLE
Add sandialabs/atlas-ui-3 (closes #26)

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1436,5 +1436,11 @@
     "tags": [
       "orchestration"
     ]
+  },
+  {
+    "repo": "sandialabs/atlas-ui-3",
+    "tags": [
+      "web-app"
+    ]
   }
 ]


### PR DESCRIPTION
Adds [sandialabs/atlas-ui-3](https://github.com/sandialabs/atlas-ui-3) (suggested in #26), tagged `web-app`.

| Repo | Tags | Stars | Last push | License |
|---|---|---|---|---|
| [sandialabs/atlas-ui-3](https://github.com/sandialabs/atlas-ui-3) | `web-app` | 37 | 2026-06-19 | MIT (not auto-detected) |

### Why it's in scope
A full-stack LLM chat UI (with MCP, RAG, agentic workflows) from Sandia National Labs. Its `atlas/config/llmconfig.yml` uses a generic OpenAI-compatible client (per-model `model_url` + `api_key`) and already ships a local endpoint entry (`http://127.0.0.1:8002/v1`), so it runs **local / open-weight models** via Ollama / vLLM / LM Studio — the same bring-your-own-endpoint pattern as LibreChat and lobe-chat already in the list.

### Note
Below the condensed table's 100-star filter (37★) for now, so it won't display until it grows — but it's tracked in `repos.json` and will surface automatically on the next weekly refresh once it crosses the threshold.