### PR TITLE
Add Cogito Studio to tracked repos

### DIFF
--- a/scraper/data/repos.json
+++ b/scraper/data/repos.json
@@ -69,6 +69,18 @@
     ]
   },
   {
+    "repo": "Nexo-Agent/nexo",
+    "tags": [
+      "desktop-app",
+      "mcp-server"
+    ],
+    "platforms": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
     "repo": "nat/openplayground",
     "tags": [
       "web-app"

--- a/scraper/data/repos.json
+++ b/scraper/data/repos.json
@@ -69,7 +69,7 @@
     ]
   },
   {
-    "repo": "Nexo-Agent/nexo",
+    "repo": "CogitoForge-AI/cogito-studio",
     "tags": [
       "desktop-app",
       "mcp-server"


### PR DESCRIPTION
## Summary

- Adds [CogitoForge-AI/cogito-studio](https://github.com/CogitoForge-AI/cogito-studio) to tracked local LLM repos
- Cross-platform desktop AI workspace with MCP integration

## Tags

- desktop-app
- mcp-server

## Platforms

- Linux, macOS, Windows