### PR TITLE
Auto-discover LLM repos into a private Turso candidates pipeline

### DIFF
--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -1,0 +1,44 @@
+name: Discover candidates
+
+on:
+  schedule:
+    - cron: "0 3 * * *"    # 03:00 UTC daily (offset from update-stats' 01:00)
+  workflow_dispatch: {}     # manual trigger
+
+permissions:
+  contents: read            # writes go to Turso, nothing is committed
+
+concurrency:
+  group: discover
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scraper/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r scraper/requirements.txt
+
+      - name: Discover new candidates → Turso
+        env:
+          STATS_GH_PAT: ${{ secrets.STATS_GH_PAT }}
+          TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
+          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+        run: python scraper/discover.py
+
+      - name: Classify new candidates
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
+          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+        run: python scraper/classify.py

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,6 @@ __pycache__/
 # Generated outputs (timestamped CSVs)
 outputs/
 
-# Discovery script output (raw candidates, not curated)
-discover_candidates.json
-
 # macOS
 .DS_Store
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -40,7 +40,36 @@ CREATE INDEX IF NOT EXISTS idx_snap_repo_date ON snapshots(repo_id, scraped_date
 CREATE INDEX IF NOT EXISTS idx_snap_date      ON snapshots(scraped_date);
 CREATE INDEX IF NOT EXISTS idx_snap_stars     ON snapshots(stars DESC);
 
+-- Discovery pipeline: repos found by discover.py awaiting triage. A candidate
+-- is a repo not yet in the curated repos table. status tracks its lifecycle;
+-- rejected rows are kept so discovery never re-surfaces them.
+CREATE TABLE IF NOT EXISTS candidates (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  full_name             TEXT    NOT NULL UNIQUE,       -- "owner/name"
+  description           TEXT,
+  topics                TEXT    NOT NULL DEFAULT '[]', -- JSON array of GitHub topics
+  language              TEXT,
+  stars                 INTEGER NOT NULL DEFAULT 0,
+  archived              INTEGER NOT NULL DEFAULT 0,    -- 0/1
+  url                   TEXT,
+
+  -- classification (filled by classify.py)
+  suggested_category    TEXT,                          -- category slug
+  suggested_subcategory TEXT,                          -- subcategory slug = a repos.tags value
+  confidence            REAL,                          -- 0.0–1.0
+  reason                TEXT,                          -- one-line LLM justification
+
+  -- lifecycle: new | classified | accepted | rejected | duplicate
+  status                TEXT    NOT NULL DEFAULT 'new',
+  discovered_at         TEXT    NOT NULL DEFAULT (date('now')),
+  decided_at            TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_cand_status ON candidates(status);
+CREATE INDEX IF NOT EXISTS idx_cand_stars  ON candidates(stars DESC);
+
 -- Migration for existing databases:
 -- ALTER TABLE snapshots ADD COLUMN contributors INTEGER;
 -- ALTER TABLE repos ADD COLUMN owner_country TEXT;
 -- ALTER TABLE repos ADD COLUMN repo_created_at TEXT;
+-- (candidates table is new — CREATE TABLE IF NOT EXISTS above is safe to re-run)

--- a/scraper/classify.py
+++ b/scraper/classify.py
@@ -1,0 +1,223 @@
+"""
+LLM categorisation of discovered candidates.
+
+For every candidate with status='new', asks Claude to pick the best-fitting
+subcategory from the taxonomy in data/categories.json, then writes the
+suggestion (category, subcategory, confidence, one-line reason) back to the
+candidates table and flips status to 'classified'.
+
+The model is constrained via a strict tool whose `subcategory_slug` is an enum
+of the real taxonomy slugs — it cannot invent a category. Suggestions are
+proposals only; a human accepts/rejects via review.py before promotion.
+
+Usage:
+    python classify.py [--limit N]   (default: all status='new')
+
+Environment variables:
+    ANTHROPIC_API_KEY                    — Claude API key
+    TURSO_DATABASE_URL, TURSO_AUTH_TOKEN — Turso database
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import anthropic
+
+from turso import TursoClient
+
+
+MODEL = "claude-haiku-4-5"   # cheap + fast; classification is an easy task
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(SCRIPT_DIR, "data")
+CATEGORIES_FILE = os.path.join(DATA_DIR, "categories.json")
+
+
+_SELECT_NEW_SQL = """
+SELECT full_name, description, topics, language, stars
+FROM   candidates
+WHERE  status = 'new'
+ORDER BY stars DESC
+"""
+
+_UPDATE_CLASSIFICATION_SQL = """
+UPDATE candidates
+SET    suggested_category = ?, suggested_subcategory = ?,
+       confidence = ?, reason = ?, status = 'classified'
+WHERE  full_name = ?
+"""
+
+
+def load_taxonomy() -> tuple[list[dict], dict[str, str]]:
+    """Return (subcategories, subcategory_slug → category_slug)."""
+    with open(CATEGORIES_FILE, encoding="utf-8") as f:
+        categories = json.load(f)
+
+    subcats = []          # {category, category_slug, name, slug}
+    sub_to_cat = {}       # subcategory slug → category slug
+    for cat in categories:
+        for sub in cat["subcategories"]:
+            subcats.append({
+                "category": cat["category"],
+                "category_slug": cat["slug"],
+                "name": sub["name"],
+                "slug": sub["slug"],
+            })
+            sub_to_cat[sub["slug"]] = cat["slug"]
+    return subcats, sub_to_cat
+
+
+def build_system_prompt(subcats: list[dict]) -> str:
+    lines = [
+        "You classify open-source LLM/AI GitHub repositories into a fixed taxonomy.",
+        "Pick the single best-fitting subcategory for the repo described by the user.",
+        "Use the repo's name, description, and topics. If genuinely unsure, still pick",
+        "the closest fit but lower your confidence. Valid subcategories:",
+        "",
+    ]
+    current = None
+    for s in subcats:
+        if s["category"] != current:
+            current = s["category"]
+            lines.append(f"{s['category']}:")
+        lines.append(f"  - {s['name']} (slug: {s['slug']})")
+    return "\n".join(lines)
+
+
+def build_tool(subcats: list[dict]) -> dict:
+    slugs = [s["slug"] for s in subcats]
+    return {
+        "name": "classify_repo",
+        "description": "Record the best-fitting subcategory for this repository.",
+        "strict": True,
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "subcategory_slug": {
+                    "type": "string",
+                    "enum": slugs,
+                    "description": "Slug of the single best-fitting subcategory.",
+                },
+                "confidence": {
+                    "type": "number",
+                    "description": "Confidence in this classification, 0.0 to 1.0.",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "One-line justification (<= 120 characters).",
+                },
+            },
+            "required": ["subcategory_slug", "confidence", "reason"],
+            "additionalProperties": False,
+        },
+    }
+
+
+def classify_one(client, tool, system, cand: dict) -> dict | None:
+    """Return {subcategory_slug, confidence, reason} or None on failure."""
+    topics = ", ".join(cand["topics"]) if cand["topics"] else "(none)"
+    user = (
+        f"Repository: {cand['full_name']}\n"
+        f"Description: {cand['description'] or '(none)'}\n"
+        f"Primary language: {cand['language'] or '(unknown)'}\n"
+        f"GitHub topics: {topics}\n"
+        f"Stars: {cand['stars']:,}"
+    )
+    resp = client.messages.create(
+        model=MODEL,
+        max_tokens=512,
+        system=system,
+        tools=[tool],
+        tool_choice={"type": "tool", "name": "classify_repo"},
+        messages=[{"role": "user", "content": user}],
+    )
+    for block in resp.content:
+        if block.type == "tool_use" and block.name == "classify_repo":
+            return block.input
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Max candidates to classify this run")
+    args = parser.parse_args()
+
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        pass
+
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        sys.exit("Error: set ANTHROPIC_API_KEY")
+
+    turso_url = os.getenv("TURSO_DATABASE_URL")
+    turso_token = os.getenv("TURSO_AUTH_TOKEN")
+    if not (turso_url and turso_token):
+        sys.exit("Error: set TURSO_DATABASE_URL and TURSO_AUTH_TOKEN")
+    db = TursoClient(turso_url, turso_token)
+
+    subcats, sub_to_cat = load_taxonomy()
+    system = build_system_prompt(subcats)
+    tool = build_tool(subcats)
+    client = anthropic.Anthropic()
+
+    sql = _SELECT_NEW_SQL
+    if args.limit:
+        sql += f"\nLIMIT {int(args.limit)}"
+    rows = db.query(sql)
+    if not rows:
+        print("No candidates with status='new' to classify.")
+        return
+
+    print(f"Classifying {len(rows)} candidate(s) with {MODEL}\n")
+
+    done = 0
+    for full_name, description, topics_json, language, stars in rows:
+        cand = {
+            "full_name": full_name,
+            "description": description,
+            "topics": json.loads(topics_json) if topics_json else [],
+            "language": language,
+            "stars": stars or 0,
+        }
+        try:
+            result = classify_one(client, tool, system, cand)
+        except (anthropic.AuthenticationError, anthropic.PermissionDeniedError) as e:
+            # Bad/expired key or exhausted credit — every remaining call would
+            # fail the same way. Stop now; candidates stay 'new' for next run.
+            sys.exit(f"\nAborting: {e.__class__.__name__} — {e}\n"
+                     f"Fix the API key / billing, then re-run. "
+                     f"{done} classified so far; the rest remain 'new'.")
+        except anthropic.APIConnectionError as e:
+            # Network/timeout — unlikely to recover within this run.
+            sys.exit(f"\nAborting: connection error — {e}\n"
+                     f"{done} classified so far; the rest remain 'new'.")
+        except anthropic.APIStatusError as e:
+            # Other per-request errors (e.g. a one-off 400/500) — skip this one.
+            print(f"  API error on {full_name}: {e}")
+            continue
+
+        if not result:
+            print(f"  No classification returned for {full_name} — skipping")
+            continue
+
+        sub_slug = result["subcategory_slug"]
+        cat_slug = sub_to_cat.get(sub_slug, "")
+        confidence = float(result["confidence"])
+        reason = result["reason"]
+
+        # Checkpoint per row so a crash resumes cleanly.
+        db.execute(_UPDATE_CLASSIFICATION_SQL,
+                   [cat_slug, sub_slug, confidence, reason, full_name])
+        done += 1
+        print(f"  [{confidence:.2f}] {sub_slug:<22} {full_name}")
+
+    print(f"\nClassified {done}/{len(rows)} candidates → status='classified'")
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/discover.py
+++ b/scraper/discover.py
@@ -1,13 +1,24 @@
 """
-GitHub repo discovery — finds candidates not yet in repos.json.
+GitHub repo discovery — finds candidates not yet in the curated list and writes
+them to the Turso `candidates` table for triage.
 
-Searches GitHub Search API across LLM/agent/inference topics and keywords,
-filters to >100 stars, deduplicates, then diffs against repos.json.
+Searches the GitHub Search API across LLM/agent/inference topics and keywords,
+filters to >100 stars, deduplicates, drops repos already in repos.json, then
+upserts the rest into the candidates table.
 
-Output: discover_candidates.json  (sorted by stars desc)
+Repos already curated (in repos.json) are skipped. Repos already in the
+candidates table are refreshed in place via ON CONFLICT — crucially this does
+NOT reset their status, so anything previously reviewed and marked 'rejected'
+stays rejected and never re-surfaces as new.
+
+Output: rows in the Turso `candidates` table (status='new' for genuinely new repos).
 
 Usage:
     python discover.py [--min-stars N]  (default 100)
+
+Environment variables:
+    STATS_GH_PAT / GITHUB_TOKEN / GITHUB_API_TOKEN  — GitHub token (search)
+    TURSO_DATABASE_URL, TURSO_AUTH_TOKEN            — Turso database
 """
 
 import json
@@ -19,18 +30,17 @@ from datetime import datetime
 
 import requests
 
+from turso import TursoClient
+
 
 SEARCH_URL = "https://api.github.com/search/repositories"
 MAX_PAGES = 3       # up to 300 results per query (100/page)
 REQUEST_DELAY = 2.5 # seconds between requests (search rate limit: 30/min)
 
-# This script lives in scraper/; data sits in scraper/data/ and the raw
-# candidate dump is written to the repo root (the parent directory).
+# This script lives in scraper/; data sits in scraper/data/.
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(SCRIPT_DIR, "data")
-REPO_ROOT = os.path.dirname(SCRIPT_DIR)
 REPOS_FILE = os.path.join(DATA_DIR, "repos.json")
-CANDIDATES_FILE = os.path.join(REPO_ROOT, "discover_candidates.json")
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +95,25 @@ KEYWORD_SEARCHES = [
     "rag framework in:name,description stars:>200 is:public",
     "document qa in:name,description stars:>100 is:public",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Candidate upsert
+# ---------------------------------------------------------------------------
+
+# Refreshes an existing candidate's stats without touching status/classification,
+# so a rejected repo stays rejected and a classified one keeps its category.
+_UPSERT_CANDIDATE_SQL = """
+INSERT INTO candidates (full_name, description, topics, language, stars, archived, url)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(full_name) DO UPDATE SET
+  stars       = excluded.stars,
+  description = excluded.description,
+  topics      = excluded.topics,
+  language    = excluded.language,
+  archived    = excluded.archived,
+  url         = excluded.url
+"""
 
 
 # ---------------------------------------------------------------------------
@@ -176,9 +205,22 @@ def main():
     if not token:
         sys.exit("Error: set STATS_GH_PAT, GITHUB_TOKEN, or GITHUB_API_TOKEN")
 
+    turso_url = os.getenv("TURSO_DATABASE_URL")
+    turso_token = os.getenv("TURSO_AUTH_TOKEN")
+    if not (turso_url and turso_token):
+        sys.exit("Error: set TURSO_DATABASE_URL and TURSO_AUTH_TOKEN")
+    db = TursoClient(turso_url, turso_token)
+
+    # Repos already curated — never surface these as candidates.
     with open(REPOS_FILE, encoding="utf-8") as f:
-        existing = json.load(f)
-    existing_names = {e["repo"].lower() for e in existing}
+        curated = json.load(f)
+    curated_names = {e["repo"].lower() for e in curated}
+
+    # Candidates already tracked (any status) — used only to report which repos
+    # are genuinely new this run; the upsert refreshes the rest in place.
+    existing_cand_names = {
+        row[0].lower() for row in db.query("SELECT full_name FROM candidates")
+    }
 
     session = make_session(token)
     all_items: dict[str, dict] = {}  # full_name → item
@@ -193,10 +235,12 @@ def main():
         new_count = 0
         for item in items:
             name = item["full_name"]
-            if name.lower() not in existing_names and name not in all_items:
+            if name.lower() in curated_names:
+                continue  # already in the curated list
+            if name not in all_items:
                 all_items[name] = item
                 new_count += 1
-        print(f"    → {len(items)} results, {new_count} new candidates")
+        print(f"    → {len(items)} results, {new_count} not-yet-curated")
         time.sleep(REQUEST_DELAY)
 
     # Filter and shape candidates
@@ -217,17 +261,25 @@ def main():
 
     candidates.sort(key=lambda x: x["stars"], reverse=True)
 
-    out_path = CANDIDATES_FILE
-    with open(out_path, "w", encoding="utf-8") as f:
-        json.dump(candidates, f, indent=2, ensure_ascii=False)
+    # Upsert into the candidates table.
+    stmts = [
+        (_UPSERT_CANDIDATE_SQL, [
+            c["repo"], c["description"], json.dumps(c["topics"]),
+            c["language"], c["stars"], int(c["archived"]), c["url"],
+        ])
+        for c in candidates
+    ]
+    for i in range(0, len(stmts), 50):
+        db.executemany(stmts[i:i + 50])
+
+    new_candidates = [c for c in candidates if c["repo"].lower() not in existing_cand_names]
 
     print(f"\n{'='*60}")
-    print(f"Found {len(candidates)} candidates not in repos.json")
-    print(f"Saved to {out_path}")
+    print(f"Upserted {len(candidates)} candidates ({len(new_candidates)} new this run)")
     print(f"{'='*60}")
     print(f"\n{'Stars':>7}  {'Archived':>8}  Repo")
     print("-" * 70)
-    for c in candidates[:80]:
+    for c in new_candidates[:80]:
         archived = "[archived]" if c["archived"] else ""
         print(f"{c['stars']:>7,}  {archived:>10}  {c['repo']}")
         if c["description"]:
@@ -237,10 +289,11 @@ def main():
             print(f"           {'':>10}  topics: {', '.join(c['topics'][:6])}")
         print()
 
-    if len(candidates) > 80:
-        print(f"... and {len(candidates) - 80} more in {out_path}")
+    if len(new_candidates) > 80:
+        print(f"... and {len(new_candidates) - 80} more new candidates in the DB")
 
-    print(f"\nDiscovery complete: {len(candidates)} candidates, {datetime.now().strftime('%Y-%m-%d %H:%M')}")
+    print(f"\nDiscovery complete: {len(new_candidates)} new, "
+          f"{len(candidates)} total upserted, {datetime.now().strftime('%Y-%m-%d %H:%M')}")
 
 
 if __name__ == "__main__":

--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -4,3 +4,4 @@ pandas>=2.2
 tabulate>=0.9
 python-dotenv>=1.0
 pycountry>=22.3
+anthropic>=0.40

--- a/scraper/review.py
+++ b/scraper/review.py
@@ -1,0 +1,165 @@
+"""
+Triage classified candidates: list them, then accept or reject.
+
+- list                       Show classified candidates (highest stars first).
+- accept <repo> [slug ...]   Add repo to repos.json with the given (or suggested)
+                             subcategory tag; mark candidate 'accepted'.
+- reject <repo> ...          Mark candidate(s) 'rejected' so discovery never
+                             re-surfaces them.
+
+Accepting appends to data/repos.json (the curated source scrape.py scrapes from),
+so the repo starts getting daily snapshots on the next scrape run. platforms /
+backends are left empty for you to fill in manually.
+
+Usage:
+    python review.py list [--min-confidence F]
+    python review.py accept owner/name [subcategory-slug]
+    python review.py reject owner/name [owner/name ...]
+
+Environment variables:
+    TURSO_DATABASE_URL, TURSO_AUTH_TOKEN — Turso database
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from turso import TursoClient
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(SCRIPT_DIR, "data")
+REPOS_FILE = os.path.join(DATA_DIR, "repos.json")
+CATEGORIES_FILE = os.path.join(DATA_DIR, "categories.json")
+
+
+def get_db() -> TursoClient:
+    url = os.getenv("TURSO_DATABASE_URL")
+    token = os.getenv("TURSO_AUTH_TOKEN")
+    if not (url and token):
+        sys.exit("Error: set TURSO_DATABASE_URL and TURSO_AUTH_TOKEN")
+    return TursoClient(url, token)
+
+
+def valid_slugs() -> set[str]:
+    with open(CATEGORIES_FILE, encoding="utf-8") as f:
+        categories = json.load(f)
+    return {sub["slug"] for cat in categories for sub in cat["subcategories"]}
+
+
+def load_repos() -> list[dict]:
+    with open(REPOS_FILE, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_repos(repos: list[dict]) -> None:
+    with open(REPOS_FILE, "w", encoding="utf-8") as f:
+        json.dump(repos, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_list(db: TursoClient, args) -> None:
+    rows = db.query("""
+        SELECT full_name, stars, confidence, suggested_subcategory, reason
+        FROM   candidates
+        WHERE  status = 'classified'
+        ORDER BY stars DESC
+    """)
+    min_conf = args.min_confidence
+    shown = 0
+    print(f"{'Stars':>7}  {'Conf':>4}  {'Subcategory':<22}  Repo")
+    print("-" * 78)
+    for full_name, stars, confidence, sub, reason in rows:
+        if min_conf is not None and (confidence or 0) < min_conf:
+            continue
+        shown += 1
+        print(f"{stars or 0:>7,}  {confidence or 0:>4.2f}  {sub or '':<22}  {full_name}")
+        if reason:
+            print(f"{'':>7}  {'':>4}  {'':<22}  ↳ {reason}")
+    print("-" * 78)
+    print(f"{shown} classified candidate(s) awaiting review.")
+
+
+def cmd_accept(db: TursoClient, args) -> None:
+    full_name = args.repo
+    rows = db.query(
+        "SELECT suggested_subcategory, status FROM candidates WHERE full_name = ?",
+        [full_name],
+    )
+    if not rows:
+        sys.exit(f"Error: {full_name} is not a candidate.")
+    suggested, status = rows[0]
+
+    slug = args.slug or suggested
+    if not slug:
+        sys.exit(f"Error: {full_name} has no suggested subcategory — pass one explicitly.")
+    if slug not in valid_slugs():
+        sys.exit(f"Error: '{slug}' is not a valid subcategory slug.")
+
+    repos = load_repos()
+    if any(r["repo"].lower() == full_name.lower() for r in repos):
+        print(f"{full_name} already in repos.json — marking accepted only.")
+    else:
+        repos.append({"repo": full_name, "tags": [slug]})
+        save_repos(repos)
+        print(f"Added {full_name} to repos.json with tag '{slug}'.")
+
+    db.execute(
+        "UPDATE candidates SET status='accepted', decided_at=date('now') WHERE full_name = ?",
+        [full_name],
+    )
+    print(f"Marked {full_name} accepted. It will be scraped on the next run.")
+
+
+def cmd_reject(db: TursoClient, args) -> None:
+    for full_name in args.repos:
+        res = db.execute(
+            "UPDATE candidates SET status='rejected', decided_at=date('now') WHERE full_name = ?",
+            [full_name],
+        )
+        affected = res.get("response", {}).get("result", {}).get("affected_row_count", 0)
+        if affected:
+            print(f"Rejected {full_name}.")
+        else:
+            print(f"Not a candidate: {full_name}")
+
+
+def main() -> None:
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        pass
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_list = sub.add_parser("list", help="Show classified candidates")
+    p_list.add_argument("--min-confidence", type=float, default=None)
+
+    p_accept = sub.add_parser("accept", help="Accept a candidate into repos.json")
+    p_accept.add_argument("repo", help="owner/name")
+    p_accept.add_argument("slug", nargs="?", default=None,
+                          help="Subcategory slug (defaults to the LLM suggestion)")
+
+    p_reject = sub.add_parser("reject", help="Reject candidate(s)")
+    p_reject.add_argument("repos", nargs="+", help="one or more owner/name")
+
+    args = parser.parse_args()
+    db = get_db()
+
+    if args.command == "list":
+        cmd_list(db, args)
+    elif args.command == "accept":
+        cmd_accept(db, args)
+    elif args.command == "reject":
+        cmd_reject(db, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/scrape.py
+++ b/scraper/scrape.py
@@ -24,6 +24,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from turso import TursoClient
+
 try:
     import pycountry as _pycountry
 except ImportError:
@@ -55,78 +57,6 @@ REPO_FIELDS = """{
   releases { totalCount }
 }"""
 
-
-# ---------------------------------------------------------------------------
-# Turso HTTP client
-# ---------------------------------------------------------------------------
-
-def _arg(v) -> dict:
-    if v is None:
-        return {"type": "null"}
-    if isinstance(v, bool):
-        return {"type": "integer", "value": str(int(v))}
-    if isinstance(v, int):
-        return {"type": "integer", "value": str(v)}
-    if isinstance(v, float):
-        return {"type": "float", "value": str(v)}
-    return {"type": "text", "value": str(v)}
-
-
-class TursoClient:
-    def __init__(self, url: str, token: str) -> None:
-        # Accept libsql:// or https://
-        self.base_url = url.replace("libsql://", "https://").rstrip("/")
-        self._headers = {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        }
-
-    def _pipeline(self, stmts: list[dict]) -> list[dict]:
-        payload = {
-            "requests": [{"type": "execute", "stmt": s} for s in stmts]
-            + [{"type": "close"}]
-        }
-        r = requests.post(
-            f"{self.base_url}/v2/pipeline",
-            json=payload,
-            headers=self._headers,
-            timeout=30,
-        )
-        r.raise_for_status()
-        results = r.json().get("results", [])
-        for res in results:
-            if res.get("type") == "error":
-                raise RuntimeError(f"Turso: {res['error']['message']}")
-        return results
-
-    def execute(self, sql: str, args: Optional[list] = None) -> dict:
-        stmt: dict = {"sql": sql}
-        if args:
-            stmt["args"] = [_arg(a) for a in args]
-        return self._pipeline([stmt])[0]
-
-    def executemany(self, statements: list[tuple[str, list]]) -> list[dict]:
-        stmts = []
-        for sql, args in statements:
-            stmt: dict = {"sql": sql}
-            if args:
-                stmt["args"] = [_arg(a) for a in args]
-            stmts.append(stmt)
-        return self._pipeline(stmts)
-
-    def query(self, sql: str, args: Optional[list] = None) -> list[list]:
-        """Run a SELECT and return rows as plain Python lists."""
-        res = self.execute(sql, args)
-        raw_rows = res.get("response", {}).get("result", {}).get("rows", [])
-        def _val(v: dict):
-            if v["type"] == "null":
-                return None
-            if v["type"] == "integer":
-                return int(v["value"])
-            if v["type"] == "float":
-                return float(v["value"])
-            return v["value"]
-        return [[_val(cell) for cell in row] for row in raw_rows]
 
 
 # ---------------------------------------------------------------------------

--- a/scraper/turso.py
+++ b/scraper/turso.py
@@ -1,0 +1,83 @@
+"""
+Minimal Turso (libSQL) HTTP client, shared by scrape.py, discover.py, and
+classify.py.
+
+Talks to the Turso /v2/pipeline HTTP API directly (no libsql driver dependency).
+
+Environment variables used by callers:
+  TURSO_DATABASE_URL   — libsql://... URL from the Turso dashboard
+  TURSO_AUTH_TOKEN     — Turso auth token
+"""
+
+from typing import Optional
+
+import requests
+
+
+def _arg(v) -> dict:
+    if v is None:
+        return {"type": "null"}
+    if isinstance(v, bool):
+        return {"type": "integer", "value": str(int(v))}
+    if isinstance(v, int):
+        return {"type": "integer", "value": str(v)}
+    if isinstance(v, float):
+        return {"type": "float", "value": str(v)}
+    return {"type": "text", "value": str(v)}
+
+
+class TursoClient:
+    def __init__(self, url: str, token: str) -> None:
+        # Accept libsql:// or https://
+        self.base_url = url.replace("libsql://", "https://").rstrip("/")
+        self._headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    def _pipeline(self, stmts: list[dict]) -> list[dict]:
+        payload = {
+            "requests": [{"type": "execute", "stmt": s} for s in stmts]
+            + [{"type": "close"}]
+        }
+        r = requests.post(
+            f"{self.base_url}/v2/pipeline",
+            json=payload,
+            headers=self._headers,
+            timeout=30,
+        )
+        r.raise_for_status()
+        results = r.json().get("results", [])
+        for res in results:
+            if res.get("type") == "error":
+                raise RuntimeError(f"Turso: {res['error']['message']}")
+        return results
+
+    def execute(self, sql: str, args: Optional[list] = None) -> dict:
+        stmt: dict = {"sql": sql}
+        if args:
+            stmt["args"] = [_arg(a) for a in args]
+        return self._pipeline([stmt])[0]
+
+    def executemany(self, statements: list[tuple[str, list]]) -> list[dict]:
+        stmts = []
+        for sql, args in statements:
+            stmt: dict = {"sql": sql}
+            if args:
+                stmt["args"] = [_arg(a) for a in args]
+            stmts.append(stmt)
+        return self._pipeline(stmts)
+
+    def query(self, sql: str, args: Optional[list] = None) -> list[list]:
+        """Run a SELECT and return rows as plain Python lists."""
+        res = self.execute(sql, args)
+        raw_rows = res.get("response", {}).get("result", {}).get("rows", [])
+        def _val(v: dict):
+            if v["type"] == "null":
+                return None
+            if v["type"] == "integer":
+                return int(v["value"])
+            if v["type"] == "float":
+                return float(v["value"])
+            return v["value"]
+        return [[_val(cell) for cell in row] for row in raw_rows]


### PR DESCRIPTION
Adds automated repo discovery so new LLM repos are found and triaged instead of hand-curated: `discover.py` now searches GitHub and upserts into a new Turso `candidates` table (persisting rejections so they never re-surface) rather than a throwaway JSON file, `classify.py` assigns each candidate a taxonomy subcategory via Claude constrained to valid slugs, and `review.py` lists/accepts/rejects — accepting appends to `repos.json` so `scrape.py` scrapes it. A daily GitHub Actions workflow runs discover + classify, the shared `TursoClient` is extracted into `turso.py`, and candidate data lives only in private Turso (never committed to git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)