### PR TITLE
Add manual candidate triage workflow

### DIFF
--- a/scraper/classifier.py
+++ b/scraper/classifier.py
@@ -26,7 +26,7 @@ DATA_DIR = os.path.join(SCRIPT_DIR, "data")
 CATEGORIES_FILE = os.path.join(DATA_DIR, "categories.json")
 KEYWORDS_FILE = os.path.join(DATA_DIR, "keywords.json")
 
-MAX_SUBCATEGORIES = 2
+MAX_SUBCATEGORIES = 5
 MAX_KEYWORDS = 6
 
 
@@ -55,6 +55,8 @@ class Taxonomy:
         self.category_slugs = [c["slug"] for c in categories]
         self.subcategory_slugs = [s["slug"] for s in self.subcats]
         self.keyword_slugs = [k["slug"] for k in keywords]
+        self._cat_set = set(self.category_slugs)
+        self._sub_set = set(self.subcategory_slugs)
         self._keyword_set = set(self.keyword_slugs)
 
 
@@ -71,7 +73,10 @@ def build_system_prompt(tax: Taxonomy) -> str:
         "You classify open-source LLM/AI GitHub repositories into a fixed taxonomy.",
         "The taxonomy is three tiers:",
         "  1. category      — one broad bucket (what kind of thing the repo is).",
-        "  2. subcategories — one or two specific roles WITHIN that category.",
+        "  2. subcategories — one or more specific roles (up to 5). Assign every",
+        "     subcategory that genuinely applies; they MAY span categories when a",
+        "     repo wears more than one hat (e.g. a model that ships a training",
+        "     toolkit). Pick the single best-fitting category above as primary.",
         "  3. keywords      — cross-cutting facets (techniques, integrations,",
         "     modalities, domains) that need not match the category. Pick only",
         "     keywords the repo is clearly about; an empty list is fine.",
@@ -109,7 +114,9 @@ def build_tool(tax: Taxonomy) -> dict:
                     "minItems": 1,
                     "maxItems": MAX_SUBCATEGORIES,
                     "description": (
-                        "One or two subcategory slugs, all belonging to the chosen category."
+                        "One to five subcategory slugs — every role that genuinely "
+                        "applies. May span categories; the primary category is chosen "
+                        "separately."
                     ),
                 },
                 "keyword_slugs": {
@@ -222,27 +229,25 @@ def normalise_result(result: dict, tax: Taxonomy) -> dict:
     """
     Reconcile the model output into a consistent classification:
 
-      - keep only subcategories that belong to the chosen category;
-      - if that leaves none (model mixed categories), re-derive the category
-        from the first returned subcategory so we never lose the label;
-      - drop any keyword not in the vocabulary.
+      - keep the chosen primary category (one only); if it isn't a valid
+        category slug, derive it from the first valid subcategory's parent;
+      - keep every valid subcategory, which MAY span categories (a repo can
+        wear more than one hat) — capped at MAX_SUBCATEGORIES;
+      - drop any keyword not in the vocabulary — capped at MAX_KEYWORDS.
 
     Returns {category, subcategories, keywords, confidence, reason}.
     """
-    category = result["category_slug"]
-    subs = list(dict.fromkeys(result.get("subcategory_slugs") or []))
+    category = result.get("category_slug")
+    subs = [s for s in dict.fromkeys(result.get("subcategory_slugs") or [])
+            if s in tax._sub_set][:MAX_SUBCATEGORIES]
 
-    in_category = [s for s in subs if tax.sub_to_cat.get(s) == category]
-    if in_category:
-        subs = in_category
-    elif subs:
-        # Model's subcategories disagree with its category — trust the first
-        # subcategory and correct the category to match it.
-        category = tax.sub_to_cat.get(subs[0], category)
-        subs = [s for s in subs if tax.sub_to_cat.get(s) == category]
+    # Primary category: trust the explicit choice if valid, else fall back to
+    # the parent of the first subcategory so we never lose the label.
+    if category not in tax._cat_set:
+        category = tax.sub_to_cat.get(subs[0]) if subs else None
 
     keywords = [k for k in dict.fromkeys(result.get("keyword_slugs") or [])
-                if k in tax._keyword_set]
+                if k in tax._keyword_set][:MAX_KEYWORDS]
 
     return {
         "category": category,

--- a/scraper/review.py
+++ b/scraper/review.py
@@ -116,8 +116,11 @@ def cmd_accept(db: TursoClient, args) -> None:
     if bad:
         sys.exit(f"Error: invalid subcategory slug(s): {', '.join(bad)}")
 
-    # Derive the category from the (first) subcategory so it always matches.
-    category = tax.sub_to_cat[subcategories[0]]
+    # Use the stored primary category (subcategories may span categories, so we
+    # can't derive it from the first subcategory). Fall back to the first
+    # subcategory's parent only if the stored category is missing/invalid.
+    category = sug_category if sug_category in set(tax.category_slugs) \
+        else tax.sub_to_cat[subcategories[0]]
     keywords = [k for k in _parse_json_list(sug_keywords) if k in tax._keyword_set]
 
     repos = load_repos()

--- a/scraper/triage_batch.py
+++ b/scraper/triage_batch.py
@@ -1,0 +1,166 @@
+"""
+Manual batched triage of discovered candidates.
+
+Lets a human (or Claude) classify candidates in stars-descending batches without
+the API classifier. Two modes:
+
+    pull  — print the next N unclassified candidates (status='new'), highest
+            stars first, as compact JSON. Entries whose description is too thin
+            to classify from are flagged "needs_readme": true.
+
+    write — read a JSON array of classifications from a file and write them back
+            to the candidates table (validated + normalised against the
+            taxonomy), flipping status 'new' → 'classified'.
+
+Because status flips on write, `pull` naturally pages forward — the process is
+resumable. Classifications are proposals; a human still accepts/rejects via
+review.py.
+
+Usage:
+    python triage_batch.py pull  [--limit N] [--min-stars S]
+    python triage_batch.py write batch.json
+
+Write-file shape (one object per repo):
+    [{"repo": "owner/name", "category": "<slug>",
+      "subcategories": ["<slug>", ...], "keywords": ["<slug>", ...],
+      "confidence": 0.0-1.0, "reason": "<= 120 chars"}]
+
+Environment variables:
+    TURSO_DATABASE_URL, TURSO_AUTH_TOKEN — Turso database
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from turso import TursoClient
+from classifier import load_taxonomy, normalise_result
+
+DESC_MIN_CHARS = 30   # below this, flag needs_readme
+
+
+def get_db() -> TursoClient:
+    try:
+        from dotenv import load_dotenv
+        load_dotenv(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env"))
+    except ImportError:
+        pass
+    url = os.getenv("TURSO_DATABASE_URL")
+    token = os.getenv("TURSO_AUTH_TOKEN")
+    if not (url and token):
+        sys.exit("Error: set TURSO_DATABASE_URL and TURSO_AUTH_TOKEN")
+    return TursoClient(url, token)
+
+
+def cmd_pull(db: TursoClient, args) -> None:
+    sql = """
+        SELECT full_name, description, topics, language, stars, url
+        FROM   candidates
+        WHERE  status = 'new' AND stars >= ?
+        ORDER BY stars DESC
+        LIMIT  ?
+    """
+    rows = db.query(sql, [args.min_stars, args.limit])
+    out = []
+    for full_name, description, topics_json, language, stars, url in rows:
+        desc = (description or "").strip()
+        out.append({
+            "repo": full_name,
+            "description": desc or None,
+            "topics": json.loads(topics_json) if topics_json else [],
+            "language": language,
+            "stars": stars or 0,
+            "url": url,
+            "needs_readme": len(desc) < DESC_MIN_CHARS,
+        })
+    remaining = db.query("SELECT COUNT(*) FROM candidates WHERE status='new'")[0][0]
+    if args.compact:
+        for e in out:
+            flag = " [needs_readme]" if e["needs_readme"] else ""
+            topics = ",".join(e["topics"][:10])
+            desc = (e["description"] or "").replace("\n", " ")
+            print(f"{e['repo']} | {e['stars']}★ | {e['language'] or '?'}{flag} | "
+                  f"{desc} | topics: {topics}")
+        print(f"\n# remaining_new: {remaining}")
+    else:
+        print(json.dumps({"batch": out, "remaining_new": remaining},
+                         ensure_ascii=False, indent=2))
+
+
+# Refine 'new' or already-'classified' rows, but never overwrite a human
+# accept/reject decision.
+_WRITE_SQL = """
+UPDATE candidates
+SET    suggested_category = ?, suggested_subcategory = ?,
+       suggested_keywords = ?, confidence = ?, reason = ?, status = 'classified'
+WHERE  full_name = ? AND status IN ('new', 'classified')
+"""
+
+
+def cmd_write(db: TursoClient, args) -> None:
+    with open(args.file, encoding="utf-8") as f:
+        items = json.load(f)
+
+    tax = load_taxonomy()
+    stmts, written, problems = [], 0, []
+    for it in items:
+        repo = it.get("repo")
+        # Reuse the classifier's reconciliation: keep subs that match the
+        # category, correct the category from the first sub on mismatch, and
+        # drop any keyword outside the vocabulary.
+        result = normalise_result({
+            "category_slug": it.get("category"),
+            "subcategory_slugs": it.get("subcategories") or [],
+            "keyword_slugs": it.get("keywords") or [],
+            "confidence": it.get("confidence"),
+            "reason": it.get("reason"),
+        }, tax)
+        if not result["category"] or not result["subcategories"]:
+            problems.append(f"{repo}: missing valid category/subcategory")
+            continue
+        stmts.append((_WRITE_SQL, [
+            result["category"],
+            json.dumps(result["subcategories"]),
+            json.dumps(result["keywords"]),
+            result["confidence"],
+            result["reason"],
+            repo,
+        ]))
+        written += 1
+
+    for i in range(0, len(stmts), 50):
+        db.executemany(stmts[i:i + 50])
+
+    print(f"Wrote {written} classification(s) → status='classified'.")
+    if problems:
+        print(f"{len(problems)} skipped:")
+        for p in problems:
+            print(f"  - {p}")
+    remaining = db.query("SELECT COUNT(*) FROM candidates WHERE status='new'")[0][0]
+    print(f"{remaining} candidates still 'new'.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_pull = sub.add_parser("pull", help="Print next N unclassified candidates")
+    p_pull.add_argument("--limit", type=int, default=50)
+    p_pull.add_argument("--min-stars", type=int, default=100)
+    p_pull.add_argument("--compact", action="store_true",
+                        help="Terse one-line-per-repo output instead of JSON")
+
+    p_write = sub.add_parser("write", help="Write classifications from a JSON file")
+    p_write.add_argument("file", help="Path to classifications JSON array")
+
+    args = parser.parse_args()
+    db = get_db()
+    if args.command == "pull":
+        cmd_pull(db, args)
+    elif args.command == "write":
+        cmd_write(db, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/turso.py
+++ b/scraper/turso.py
@@ -22,7 +22,8 @@ def _arg(v) -> dict:
     if isinstance(v, int):
         return {"type": "integer", "value": str(v)}
     if isinstance(v, float):
-        return {"type": "float", "value": str(v)}
+        # Turso expects f64 as a JSON number, not a string (unlike integers).
+        return {"type": "float", "value": v}
     return {"type": "text", "value": str(v)}
 
 

--- a/scraper/update_stats.py
+++ b/scraper/update_stats.py
@@ -89,7 +89,8 @@ def _arg(v) -> dict:
     if isinstance(v, int):
         return {"type": "integer", "value": str(v)}
     if isinstance(v, float):
-        return {"type": "float", "value": str(v)}
+        # Turso expects f64 as a JSON number, not a string (unlike integers).
+        return {"type": "float", "value": v}
     return {"type": "text", "value": str(v)}
 
 

--- a/scraper/validate_taxonomy.py
+++ b/scraper/validate_taxonomy.py
@@ -59,13 +59,12 @@ def main() -> None:
                 errors.append(f"{repo}: unknown category '{category}'")
             if not subs:
                 errors.append(f"{repo}: no subcategories")
+            # Subcategories may span categories (a repo can wear more than one
+            # hat), so we only check the slug is real — not that it belongs to
+            # the primary category.
             for s in subs:
                 if s not in sub_set:
                     errors.append(f"{repo}: unknown subcategory '{s}'")
-                elif category in cat_set and tax.sub_to_cat[s] != category:
-                    errors.append(
-                        f"{repo}: subcategory '{s}' does not belong to category '{category}'"
-                    )
             for k in keywords:
                 if k not in tax._keyword_set:
                     errors.append(f"{repo}: unknown keyword '{k}'")


### PR DESCRIPTION
## Summary
Adds a manual  pull/write workflow for classifying discovered candidates in resumable batches without the API classifier.
Updates the taxonomy reconciliation so repos can keep one primary category while carrying up to five cross-category subcategories, and adjusts review/validation to respect that model.
Fixes Turso float argument encoding in both shared clients so confidence writes succeed.

## Verification
Ran .